### PR TITLE
default to verified SSL+ validate session

### DIFF
--- a/.github/workflows/ci-merge-main.yml
+++ b/.github/workflows/ci-merge-main.yml
@@ -1,10 +1,9 @@
 name: Python CI
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    # branches: [ master ]
+  pull_request_review:
+    types:
+      - submitted
 
 jobs:
   ci:
@@ -52,6 +51,10 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+      - name: Bandit Security scan
+        run: |
+          poetry run bandit -c bandit.yml -r ciscoaxl
+
       - name: Test with pytest
         run: |
           poetry run coverage run -m pytest -v
@@ -59,7 +62,3 @@ jobs:
       - name: Code Coverage Report
         run: |
           poetry run coverage report -m
-
-      - name: Bandit Security scan
-        run: |
-          poetry run bandit -c bandit.yml -r ciscoaxl

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,0 +1,50 @@
+name: Python CI
+
+on:
+  pull_request:
+    # branches: [ master ]
+
+jobs:
+  ci:
+    environment: Dev
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        poetry-version: ["1.1.13", "1.1.12"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up Poetry ${{ matrix.poetry-version }}
+        uses: abatilo/actions-poetry@v2.1.3
+        with:
+          poetry-version: ${{ matrix.poetry-version }}
+
+      - name: Set Poetry env to use Python ${{ matrix.python-version }}
+        run: |
+          poetry env use ${{ matrix.python-version }}
+
+      - name: Install dependencies with Poetry
+        run: |
+          poetry install -E github
+          echo "::set-output name=POETRY_VENV::$(poetry env info -p)"
+        id: install
+
+      - name: Lint with flake8
+        run: |
+          # work from the virtualenv
+          source ${{ steps.install.outputs.POETRY_VENV }}/bin/activate
+          # stop the build if there are Python syntax errors or undefined names
+          poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Bandit Security scan
+        run: |
+          poetry run bandit -c bandit.yml -r ciscoaxl

--- a/ciscoaxl/axl.py
+++ b/ciscoaxl/axl.py
@@ -73,7 +73,7 @@ class axl(object):
             raise Exception(f"{url} cannot be found, please try again") from None
         if ret_code == 401:
             raise Exception(
-                f"[401 Unauthorized]: Please check your username and password"
+                "[401 Unauthorized]: Please check your username and password"
             )
         elif ret_code == 403:
             raise Exception(

--- a/ciscoaxl/axl.py
+++ b/ciscoaxl/axl.py
@@ -34,12 +34,13 @@ class axl(object):
     Python 3.6
     """
 
-    def __init__(self, username, password, cucm, cucm_version):
+    def __init__(self, username, password, cucm, cucm_version, strict_ssl=False):
         """
         :param username: axl username
         :param password: axl password
         :param cucm: UCM IP address
         :param cucm_version: UCM version
+        :param strict_ssl: raise exception on SSL failure, default False
 
         example usage:
         >>> from axl import AXL
@@ -60,6 +61,9 @@ class axl(object):
         try:
             ret_code = session.get(url, stream=True, timeout=10).status_code
         except SSLError:
+            if strict_ssl:
+                raise
+
             # retry with verify set False
             session.close()
             session = Session()

--- a/ciscoaxl/axl.py
+++ b/ciscoaxl/axl.py
@@ -14,7 +14,6 @@ from pathlib import Path
 import os
 import json
 from requests import Session
-from requests.auth import HTTPBasicAuth
 from requests.exceptions import SSLError, ConnectionError
 import re
 import urllib3

--- a/ciscoaxl/axl.py
+++ b/ciscoaxl/axl.py
@@ -33,7 +33,7 @@ class axl(object):
     Python 3.6
     """
 
-    def __init__(self, username, password, cucm, cucm_version, strict_ssl=True):
+    def __init__(self, username, password, cucm, cucm_version, strict_ssl=False):
         """
         :param username: axl username
         :param password: axl password
@@ -2383,7 +2383,7 @@ class axl(object):
         else:
             return "Device Profile not found for user"
 
-    def update_user_credentials(self, userid, password="", pin=""): #nosec
+    def update_user_credentials(self, userid, password="", pin=""):  # nosec
         """
         Update end user for credentials
         :param userid: User ID
@@ -2392,16 +2392,18 @@ class axl(object):
         :return: result dictionary
         """
 
-        if password == "" and pin == "": #nosec
+        if password == "" and pin == "":  # nosec
             return "Password and/or Pin are required"
 
-        elif password != "" and pin != "": #nosec
+        elif password != "" and pin != "":  # nosec
             try:
-                return self.client.updateUser(userid=userid, password=password, pin=pin) #nosec
+                return self.client.updateUser(
+                    userid=userid, password=password, pin=pin
+                )  # nosec
             except Fault as e:
                 return e
 
-        elif password != "": #nosec
+        elif password != "":  # nosec
             try:
                 return self.client.updateUser(userid=userid, password=password)
             except Fault as e:

--- a/ciscoaxl/axl.py
+++ b/ciscoaxl/axl.py
@@ -34,13 +34,13 @@ class axl(object):
     Python 3.6
     """
 
-    def __init__(self, username, password, cucm, cucm_version, strict_ssl=False):
+    def __init__(self, username, password, cucm, cucm_version, strict_ssl=True):
         """
         :param username: axl username
         :param password: axl password
         :param cucm: UCM IP address
         :param cucm_version: UCM version
-        :param strict_ssl: raise exception on SSL failure, default False
+        :param strict_ssl: do not work around an SSL failure, default True
 
         example usage:
         >>> from axl import AXL

--- a/ciscoaxl/axl.py
+++ b/ciscoaxl/axl.py
@@ -39,7 +39,7 @@ class axl(object):
         :param password: axl password
         :param cucm: UCM IP address
         :param cucm_version: UCM version
-        :param strict_ssl: do not work around an SSL failure, default True
+        :param strict_ssl: do not work around an SSL failure, default False
 
         example usage:
         >>> from axl import AXL

--- a/ciscoaxl/axl.py
+++ b/ciscoaxl/axl.py
@@ -56,7 +56,6 @@ class axl(object):
 
         # validate session before assigning to Transport
         url = f"https://{cucm}:8443/axl/"
-        session.verify = False
         try:
             ret_code = session.get(url, stream=True, timeout=10).status_code
         except SSLError:


### PR DESCRIPTION
Attempts to address Issue #8 (SSL verification disabled)

`requests` [uses the host's CA store by default](https://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification), no extra configuration is needed. However, in case of SSL failure, we can revert to `session.verify = False`.

Added an optional `__init__` argument `strict_ssl` which defaults to True. This causes any SSLError to be raised instead of handled by reverting back to unverified SSL. This may not be necessary, but the thought behind it is that if a user encounters an SSL issue, they can set this value to False to potentially solve the issue. The alternative would be to allow fallback to unverified SSL by default, which could potentially leave the user more vulnerable to MitM attacks. 

(I am not sure how likely these kinds of attacks would be, so if the `strict_ssl` arg is unnecessary, you can remove the "optional arg to require SSL" and "strict_ssl default to True" commits)